### PR TITLE
Restore trailing newline to master.cf template

### DIFF
--- a/templates/etc/postfix/master.cf/postfix_services.j2
+++ b/templates/etc/postfix/master.cf/postfix_services.j2
@@ -27,3 +27,4 @@ virtual   unix  -       n       n       -       -       virtual
 lmtp      unix  -       -       -       -       -       lmtp
 anvil     unix  -       -       -       -       1       anvil
 scache    unix  -       -       -       -       1       scache
+


### PR DESCRIPTION
The indentation fixes in #77 included elimination of trailing newlines in files. That was OK for most templates that included a conditional closing statement, but in the case of postfix_services.j2 it caused the next appended template snippet to run into the command arguments of the scache service.

Results from current template (incorrect):
```
scache    unix  -       -       -       -       1       scache#uucp requires: +uucp
```
Results from fixed template (correct):
```
scache    unix  -       -       -       -       1       scache
#uucp requires: +uucp
```
